### PR TITLE
attempting fix that enables no-index but doesnt nuke us

### DIFF
--- a/sites/blog/gatsby-config.js
+++ b/sites/blog/gatsby-config.js
@@ -63,7 +63,11 @@ module.exports = {
     {
       resolve: `gatsby-plugin-netlify`,
       options: {
-        headers: {},
+        headers: {
+          "https://:blog-ctg.pages.dev/*": [
+            "X-Robots-Tag: noindex",
+          ],
+        },
       }
     },
     {


### PR DESCRIPTION
https://developers.cloudflare.com/pages/configuration/headers/#prevent-your-pagesdev-deployments-showing-in-search-results