### PR TITLE
Follow-up: restore legacy /blog/YYYY/MM/slug/ URL matching in Astro routes

### DIFF
--- a/sites/new-blog/package.json
+++ b/sites/new-blog/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@astrojs/mdx": "^4.0.0",
+    "@sindresorhus/slugify": "^3.0.0",
     "astro": "^5.2.0",
     "clsx": "^2.1.1"
   },

--- a/sites/new-blog/src/content.config.ts
+++ b/sites/new-blog/src/content.config.ts
@@ -10,6 +10,7 @@ const posts = defineCollection({
     title: z.string(),
     date: z.coerce.date(),
     excerpt: z.string().optional(),
+    slug: z.string().optional(),
     tags: z.array(z.string()).optional()
   })
 });

--- a/sites/new-blog/src/pages/blog/[...slug].astro
+++ b/sites/new-blog/src/pages/blog/[...slug].astro
@@ -1,12 +1,19 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { getCollection, render } from 'astro:content';
+import { getLegacyBlogPostPath } from '../../utils/post-path';
 
 export async function getStaticPaths() {
   const posts = await getCollection('posts');
 
   return posts.map((post) => ({
-    params: { slug: post.id.replace(/\/index$/, '') },
+    params: {
+      slug: getLegacyBlogPostPath({
+        id: post.id,
+        date: post.data.date,
+        frontmatterSlug: post.data.slug
+      }).replace(/^\/blog\//, '').replace(/\/$/, '')
+    },
     props: { post }
   }));
 }

--- a/sites/new-blog/src/pages/index.astro
+++ b/sites/new-blog/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { getCollection } from 'astro:content';
+import { getLegacyBlogPostPath } from '../utils/post-path';
 
 const posts = (await getCollection('posts')).sort(
   (a, b) => b.data.date.getTime() - a.data.date.getTime()
@@ -12,7 +13,7 @@ const posts = (await getCollection('posts')).sort(
     posts.map((post) => (
       <article>
         <h3>
-          <a href={`/blog/${post.id.replace(/\/index$/, '')}/`}>{post.data.title}</a>
+          <a href={getLegacyBlogPostPath({ id: post.id, date: post.data.date, frontmatterSlug: post.data.slug })}>{post.data.title}</a>
         </h3>
         <small>{post.data.date.toDateString()}</small>
         {post.data.excerpt && <p>{post.data.excerpt}</p>}

--- a/sites/new-blog/src/utils/post-path.ts
+++ b/sites/new-blog/src/utils/post-path.ts
@@ -1,0 +1,45 @@
+import slugify from '@sindresorhus/slugify';
+
+const DATE_PREFIX_REGEX = /^\d{4}-\d{1,2}-\d{1,2}-/;
+
+const removeIndexSuffix = (id: string) => id.replace(/\/index$/, '');
+
+const getRelativeDirectory = (id: string) => {
+  const normalizedId = removeIndexSuffix(id);
+  const parts = normalizedId.split('/').filter(Boolean);
+
+  return parts[parts.length - 1] ?? normalizedId;
+};
+
+const getPostSlug = (id: string, frontmatterSlug?: string) => {
+  if (frontmatterSlug) {
+    return frontmatterSlug;
+  }
+
+  const relativeDirectory = getRelativeDirectory(id);
+  const relativeDirectoryWithoutDate = relativeDirectory.replace(DATE_PREFIX_REGEX, '');
+
+  return slugify(relativeDirectoryWithoutDate);
+};
+
+const getPostYearMonth = (date: Date) => {
+  const year = date.getFullYear().toString();
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+
+  return { year, month };
+};
+
+export const getLegacyBlogPostPath = ({
+  id,
+  date,
+  frontmatterSlug,
+}: {
+  id: string;
+  date: Date;
+  frontmatterSlug?: string;
+}) => {
+  const slug = getPostSlug(id, frontmatterSlug);
+  const { year, month } = getPostYearMonth(date);
+
+  return `/blog/${year}/${month}/${slug}/`;
+};


### PR DESCRIPTION
### Motivation
- Ensure the Astro migration emits the same post URLs as the live Gatsby site to avoid internal link breakage and 404s for existing inbound links.

### Description
- Updated the Astro post route generator in `sites/new-blog/src/pages/blog/[...slug].astro` to produce `/blog/YYYY/MM/<slug>/` style paths instead of using `post.id` directly.
- Added a reusable helper `sites/new-blog/src/utils/post-path.ts` that mirrors Gatsby slug conventions by honoring frontmatter `slug`, stripping date prefixes from directory names, and slugifying with `@sindresorhus/slugify`.
- Applied the same legacy path helper to the homepage links in `sites/new-blog/src/pages/index.astro` and extended the content schema in `sites/new-blog/src/content.config.ts` to include an optional `slug` frontmatter field.
- Added `@sindresorhus/slugify` to `sites/new-blog/package.json` dependencies to reproduce legacy slug behavior.

### Testing
- Ran `npm install --legacy-peer-deps` in `sites/new-blog` which completed successfully after workspace peer conflicts; the command succeeded.
- Ran `npm run build` in `sites/new-blog` and the build completed successfully and generated legacy-style routes (for example: `/blog/2022/03/how-to-make-a-button-intro/`).
- The build output enumerated the generated static routes and completed without errors, confirming URL alignment with the legacy Gatsby format.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ab5386a5c832fa01d9aa7134a7361)